### PR TITLE
wrote Note unit tests

### DIFF
--- a/lib/scripts/note.js
+++ b/lib/scripts/note.js
@@ -1,13 +1,13 @@
 class Note {
- constructor(options) {
-   this.note = options.note || null;
-   this.time = options.time || Date.now();
- }
+  constructor(content) {
+    this.content = content || null;
+    this.time = Date.now();
+  }
 
- updateNote(newNote) {
-   this.note = newNote;
- }
-
+  updateContent(newContent) {
+    this.content = newContent;
+    this.time = Date.now();
+  }
 
 }
 

--- a/main.bundle.js
+++ b/main.bundle.js
@@ -448,13 +448,14 @@
 /***/ function(module, exports) {
 
 	class Note {
-	  constructor(options) {
-	    this.note = options.note || null;
-	    this.time = options.time || Date.now();
+	  constructor(content) {
+	    this.content = content || null;
+	    this.time = Date.now();
 	  }
 
-	  updateNote(newNote) {
-	    this.note = newNote;
+	  updateContent(newContent) {
+	    this.content = newContent;
+	    this.time = Date.now();
 	  }
 
 	}

--- a/test.bundle.js
+++ b/test.bundle.js
@@ -116,13 +116,14 @@
 /***/ function(module, exports) {
 
 	class Note {
-	  constructor(options) {
-	    this.note = options.note || null;
-	    this.time = options.time || Date.now();
+	  constructor(content) {
+	    this.content = content || null;
+	    this.time = Date.now();
 	  }
 
-	  updateNote(newNote) {
-	    this.note = newNote;
+	  updateContent(newContent) {
+	    this.content = newContent;
+	    this.time = Date.now();
 	  }
 
 	}
@@ -8356,12 +8357,54 @@
 /* 60 */
 /***/ function(module, exports, __webpack_require__) {
 
+	/* globals describe, it, context */
+
 	const assert = __webpack_require__(19).assert;
 	const Note = __webpack_require__(6);
 
-	describe('our test bundle', function () {
-	  it('should work', function () {
-	    assert(true);
+	describe('Note', function () {
+	  var note;
+
+	  context('constructor', function () {
+
+	    it('should default this.content to a value of null', function () {
+	      note = new Note();
+
+	      assert.equal(note.content, null);
+	    });
+
+	    it('can receive a different value as an argument', function () {
+	      note = new Note('programming');
+
+	      assert.equal(note.content, 'programming');
+	    });
+
+	    it('should default this.time to a number value', function () {
+	      note = new Note();
+
+	      assert.equal(typeof note.time, 'number');
+	    });
+	  });
+
+	  context('updateContent', function () {
+
+	    it('should update content of note', function () {
+	      note = new Note();
+	      var newContent = 'hello again';
+	      note.updateContent(newContent);
+
+	      assert.equal(note.content, newContent);
+	    });
+
+	    it('should update time of note', function () {
+	      note = new Note();
+	      var pastTime = note.time;
+
+	      setTimeout(function () {
+	        note.updateContent('');
+	        assert.notEqual(note.time, pastTime);
+	      }, 1000);
+	    });
 	  });
 	});
 

--- a/test/note-test.js
+++ b/test/note-test.js
@@ -1,8 +1,52 @@
+/* globals describe, it, context */
+
 const assert = require('chai').assert;
 const Note = require('../lib/scripts/note');
 
-describe('our test bundle', function () {
-  it('should work', function () {
-    assert(true);
+describe('Note', function () {
+  var note;
+
+  context('constructor', function () {
+
+    it('should default this.content to a value of null', function () {
+      note = new Note();
+
+      assert.equal(note.content, null);
+    });
+
+    it('can receive a different value as an argument', function () {
+      note = new Note('programming');
+
+      assert.equal(note.content, 'programming');
+    });
+
+    it('should default this.time to a number value', function () {
+      note = new Note();
+
+      assert.equal(typeof note.time, 'number');
+    });
   });
+
+  context('updateContent', function () {
+
+    it('should update content of note', function () {
+      note = new Note();
+      var newContent = 'hello again';
+      note.updateContent(newContent);
+
+      assert.equal(note.content, newContent);
+    });
+
+    it('should update time of note', function () {
+      note = new Note();
+      var pastTime = note.time;
+
+      setTimeout(function() {
+        note.updateContent('');
+        assert.notEqual(note.time, pastTime);
+      }, 1000);
+    });
+
+  });
+
 });


### PR DESCRIPTION
In the Note constructor I renamed "note" to "content" so I wasn't having to write `note.note` in my tests.

@kerrd89 I think you will need to change this line in your code from:
 ```
addNote(text) {
   var note = new Note({note: text});
   this.notes.push(note);
 }
```

to look like this:
 ```
addNote(text) {
   var note = new Note({content: text});
   this.notes.push(context);
 }
```
But I didn't want to do it and screw up your stuff.